### PR TITLE
Fix header & footer inconsistent heights

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -9,4 +9,3 @@
 @import "layout/status";
 @import "layout/nav";
 @import "layout/article";
-

--- a/app/styles/layout/_aside.scss
+++ b/app/styles/layout/_aside.scss
@@ -12,11 +12,11 @@ aside {
     font-weight: bold;
     letter-spacing: 1px;
     padding-left: 0.5em;
-    text-transform: uppercase;  
+    text-transform: uppercase;
   }
 
   @include desktop {
-    grid-area: 2 / 2 / 4 / 3;
+    grid-area: aside;
   }
 }
 

--- a/app/styles/layout/_core.scss
+++ b/app/styles/layout/_core.scss
@@ -21,9 +21,8 @@ body {
   @include desktop {
     display: grid;
     grid-template-columns: 80% 20%;
-    grid-template-rows: 8% auto 3%;
-    grid-column-gap: 0px;
-    grid-row-gap: 0px;
+    grid-template-rows: 1fr auto 1fr;
+    grid-gap: 0 0;
     grid-template-areas:
       "header header"
       "main aside"

--- a/app/styles/layout/_footer.scss
+++ b/app/styles/layout/_footer.scss
@@ -10,6 +10,6 @@ footer {
   }
 
   @include desktop {
-    grid-area: 4 / 1 / 5 / 3;
+    grid-area: footer;
   }
 }

--- a/app/styles/layout/_header.scss
+++ b/app/styles/layout/_header.scss
@@ -6,14 +6,13 @@ header {
   color: $secondary_color;
   display: flex;
   flex-flow: row wrap;
-  min-height: 8vh;
+  min-height: 60px;
   width: 100%;
   h1 {
     display: flex;
     font-size: 1.85em;
     font-weight: normal;
     justify-content: flex-start;
-    line-height: 1;
     margin: 0;
     padding-left: 0.5em;
     width: 100%;

--- a/app/styles/layout/_header.scss
+++ b/app/styles/layout/_header.scss
@@ -28,6 +28,6 @@ header {
   }
 
   @include desktop {
-    grid-area: 1 / 1 / 2 / 3;
+    grid-area: header;
   }
 }

--- a/app/styles/layout/_main.scss
+++ b/app/styles/layout/_main.scss
@@ -18,7 +18,7 @@ main {
   }
 
   @include desktop {
-    grid-area: 2 / 1 / 4 / 2;
+    grid-area: main;
     max-width: 64em;
   }
 }


### PR DESCRIPTION
This Pull Request aims to fix the inconsistent height of the header and footer elements.
As shown below, depending on the height of the window the header and the footer can be "squashed" due to the percentages set in `grid-template-rows`

I was trying to make the sidebar responsive by sliding from right on mobile as well, but it isn't working yet.
Let me know if this is something you're interested in :]

![image](https://user-images.githubusercontent.com/39390862/96957049-0552d600-14d0-11eb-8526-9e4465ac760e.png)
