### PR TITLE
Fix fastboot async request leak

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,8 +1,0 @@
-import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
-export default class ApplicationRoute extends Route {
-  @service store;
-  model() {
-    return this.store.findAll('violation');
-  }
-}

--- a/app/routes/violations.js
+++ b/app/routes/violations.js
@@ -1,9 +1,0 @@
-import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
-
-export default class violationsRoute extends Route {
-  @service store;
-  model() {
-    return this.store.findAll('violation');
-  }
-}

--- a/app/routes/violations/violation.js
+++ b/app/routes/violations/violation.js
@@ -11,4 +11,11 @@ export default class violationsviolationRoute extends Route {
     return this.store.findRecord('violation', params.id);
 
   }
+
+  // make sure that tags are loaded in ember-data before template is rendered
+  // to ensure fastboot has all data on time
+  async afterModel(model) {
+    await model.get('tags');
+    return model;
+  }
 }

--- a/violations/only-one-main.md
+++ b/violations/only-one-main.md
@@ -1,7 +1,7 @@
 ---
 title: Single Main Landmark
-tags: 
-  - wgac-1-1-1
+tags:
+  - wcag-1-1-1
 linting: cannotexist
 testing: exists
 author: couldexist


### PR DESCRIPTION
Fixes https://github.com/MelSumner/a11y-automation/issues/174

Sorry when I looked at this first I wasn't sure what the issue was, I didn't realise that you were seeing those error in the **terminal** and not in the **console** in the browser.

Essentially the warning about async request leakage is possibly the worst error message I have seen in a while 🙈 and if you actually try to follow the instructions that it gives you to `set \`store.generateStackTracesForTrackedRequests = true;\`` that doesn't give you any clearer information about the problem.

The issue is a bit of a nuanced one. In Ember in the browser if you load an ember-data model and then try to render one of its relationships in the browser it will **automatically request** the data about that relationship if it doesn't have it already. This same lifecycle is not available to us in Fastboot land, instead it only renders the first render to the HTML and essentially "gives up" on any unloaded relationships.

Your instinct to make this less Async was correct, but we can't rely on setting `async: false` on the models because the data architecture requires us to leave it as async, so the solution is to just make sure that the relationships that we know we need are loaded before we start rendering the template 👍 

I also removed 2 unnecessary routes that were loading data for templates where they didn't seem needed. It is worth checking that I haven't broken anything but this now removes all the warnings you have in the terminal about async request leak 🎉 