### PR TITLE
added additional info to area map violation

### DIFF
--- a/blueprints/violations/files/violations/__name__.md
+++ b/blueprints/violations/files/violations/__name__.md
@@ -1,10 +1,10 @@
 ---
 title:
-tags: 
-linting: 
-testing: 
-author: 
-manual: 
+tags:
+linting:
+testing:
+author:
+manual:
 ---
 
 ## Point of Failure
@@ -14,6 +14,8 @@ manual:
 
 ### Linting
 Automated linting exists. See the [`ember-template-lint`](https://github.com/ember-template-lint/ember-template-lint) library for the `xxx` rule.
+
+See [axe Accessibility Linter](https://marketplace.visualstudio.com/items?itemName=deque-systems.vscode-axe-linter): For the [xxx]() rule.
 
 Potentially Automatable.
 

--- a/violations/areas-in-img-maps.md
+++ b/violations/areas-in-img-maps.md
@@ -1,6 +1,6 @@
 ---
 title: Area Elements in Image Maps
-tags: 
+tags:
   - wcag-1-1-1
   - wcag-2-4-4
   - wcag-4-1-2
@@ -11,12 +11,14 @@ manual: exists
 ---
 
 ## Point of Failure
-The `<area>` elements of image maps should have `alt` attributes with valid values.
+The `<area>` elements of image maps that are active should have `alt` attributes with valid values.
 
 ## Automation
 
 ### Linting
 See Ember Template Lint: [require-valid-alt-text](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/require-valid-alt-text.md).
+
+See [axe Accessibility Linter](https://marketplace.visualstudio.com/items?itemName=deque-systems.vscode-axe-linter): For the [aria-alt](https://dequeuniversity.com/rules/axe/4.1/area-alt) rule.
 
 ### Testing
 Potentially Automatable. Review linting equivalent and adapt for testing suite.
@@ -25,4 +27,4 @@ Potentially Automatable. Review linting equivalent and adapt for testing suite.
 Developers should ensure that their code does not violate this rule, and write a test that prevents regressions in code if it is later changed.
 
 ### Manual Test
-Inspect DOM. If image maps exist, ensure that `<area>` elements have valid `alt` attributes.
+Inspect DOM. If image maps exist, ensure that active `<area>` elements have valid `alt` attributes.


### PR DESCRIPTION
If merged, this PR: 

- updates the violations blueprint to include default language for the axe A11y Linter
- updates the area-alt violation to include the axe A11y Linting rule information