### PR TITLE
Add primary WCAG criteria to table on details page

### DIFF
--- a/app/components/sortable-table.hbs
+++ b/app/components/sortable-table.hbs
@@ -67,12 +67,43 @@
           </div>
         </button>
       </th>
+      <th scope="col" class="sortable text-left">
+        <button
+          class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase"
+          type="button" {{on "click" (fn this.sortBy "manual" )}}>
+          <span class="col-heading m-2">Manual Testing Status</span>
+          <div class="sort-arrow inline-block w-4" aria-hidden="true">
+            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-asc hidden" width="100%" height="100%"
+              viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2"
+                d="M3,9.988c-0.543,-0.007 -0.988,-0.456 -0.988,-1c0,-0.259 0.101,-0.509 0.281,-0.695l4,-4c0.388,-0.388 1.026,-0.388 1.414,-0l4,4c0.388,0.388 0.388,1.026 -0,1.414c-0.23,0.23 -0.548,0.324 -0.85,0.281l-7.857,-0l0,-0Z" />
+            </svg>
+            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-asc"
+              viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd"
+                d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z"
+                clip-rule="evenodd" />
+            </svg>
+            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-desc"
+              viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd"
+                d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                clip-rule="evenodd" />
+            </svg>
+            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-desc hidden" width="100%"
+              height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2"
+                d="M3,4.012c-0.543,0.007 -0.988,0.456 -0.988,1c0,0.259 0.101,0.509 0.281,0.695l4,4c0.388,0.388 1.026,0.388 1.414,-0l4,-4c0.388,-0.388 0.388,-1.026 -0,-1.414c-0.23,-0.23 -0.548,-0.324 -0.85,-0.281l-7.857,0l0,0Z" />
+            </svg>
+          </div>
+        </button>
+      </th>
       <th
         scope="col"
         class="sortable text-left"
       >
-        <button class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase" type="button" {{on "click" (fn this.sortBy "manual")}}>
-          <span class="col-heading m-2">Manual Testing Status</span>
+        <button class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase" type="button" {{on "click" (fn this.sortBy "webAimLevel")}}>
+          <span class="col-heading m-2">Level</span>
           <div class="sort-arrow inline-block w-4" aria-hidden="true">
             <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-asc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
               <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,9.988c-0.543,-0.007 -0.988,-0.456 -0.988,-1c0,-0.259 0.101,-0.509 0.281,-0.695l4,-4c0.388,-0.388 1.026,-0.388 1.414,-0l4,4c0.388,0.388 0.388,1.026 -0,1.414c-0.23,0.23 -0.548,0.324 -0.85,0.281l-7.857,-0l0,-0Z"/>
@@ -118,6 +149,11 @@
         <td class="px-6 py-4 whitespace-nowrap text-base text-gray-500">
           <span class="status status-{{cellitem.manual}}">
             {{cellitem.manualText}}
+          </span>
+        </td>
+        <td class="px-6 py-4 whitespace-nowrap text-base text-gray-500">
+          <span class="status level-{{cellitem.webAimLevel}}">
+            {{cellitem.webAimLevel}}
           </span>
         </td>
       </tr>

--- a/app/models/violation.js
+++ b/app/models/violation.js
@@ -37,4 +37,9 @@ export default class violationModel extends Model {
   get authorText() {
     return STATUS_TEXTS[this.author];
   }
+
+  get webAimLevel() {
+    let filteredLevels = ['A', 'AA', 'AAA'];
+    return this.tags.find(tag => filteredLevels.includes(tag?.level))?.level;
+  }
 }

--- a/app/routes/violations/index.js
+++ b/app/routes/violations/index.js
@@ -3,7 +3,8 @@ import { inject as service } from '@ember/service';
 
 export default class violationsIndexRoute extends Route {
   @service store;
-  model() {
-    return this.store.findAll('violation');
+  async model() {
+    await this.store.findAll("tag");
+    return this.store.findAll("violation");
   }
 }

--- a/app/styles/utilities.css
+++ b/app/styles/utilities.css
@@ -17,6 +17,15 @@
 .status-shouldexist {
   @apply bg-purple-100 text-purple-900 border-purple-300 bg-opacity-60;
 }
+.level-A {
+  @apply bg-green-100 text-green-900 border-green-300 bg-opacity-60;
+}
+.level-AA {
+  @apply bg-yellow-100 text-yellow-900 border-yellow-300 bg-opacity-60;
+}
+.level-AAA {
+  @apply bg-red-100 text-red-900 border-red-300 bg-opacity-60;
+}
 /* purgecss end ignore */
 h1 {
   @apply text-3xl font-bold;


### PR DESCRIPTION
This PR addresses issue #157 by adding a computed property for wcag level to the violation model then listing this property as a new column in the potential violations page.