### PR TITLE
Make the sortOrder and sortBy values queryParams for violation list

### DIFF
--- a/app/components/sortable-table-header.hbs
+++ b/app/components/sortable-table-header.hbs
@@ -1,0 +1,31 @@
+<th
+  scope="col"
+  class="sortable text-left"
+  aria-sort={{if (eq @field @sortBy) (concat @sortOrder 'ending')}}
+>
+  <button class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase" type="button" {{on "click" (fn @setSortBy @field)}}>
+    <span class="col-heading m-2">{{yield}}</span>
+    <div class="sort-arrow inline-block w-4" aria-hidden="true">
+      {{#if (and (eq @field @sortBy) (eq @sortOrder "asc"))}}
+        <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-asc" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+          <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,9.988c-0.543,-0.007 -0.988,-0.456 -0.988,-1c0,-0.259 0.101,-0.509 0.281,-0.695l4,-4c0.388,-0.388 1.026,-0.388 1.414,-0l4,4c0.388,0.388 0.388,1.026 -0,1.414c-0.23,0.23 -0.548,0.324 -0.85,0.281l-7.857,-0l0,-0Z"/>
+        </svg>
+      {{else}}
+        <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-asc" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd" />
+        </svg>
+      {{/if}}
+
+      {{#if (and (eq @field @sortBy) (eq @sortOrder "desc"))}}
+        <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-desc" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+          <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,4.012c-0.543,0.007 -0.988,0.456 -0.988,1c0,0.259 0.101,0.509 0.281,0.695l4,4c0.388,0.388 1.026,0.388 1.414,-0l4,-4c0.388,-0.388 0.388,-1.026 -0,-1.414c-0.23,-0.23 -0.548,-0.324 -0.85,-0.281l-7.857,0l0,0Z"/>
+        </svg>
+      {{else}}
+        <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-desc" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+      {{/if}}
+
+    </div>
+  </button>
+</th>

--- a/app/components/sortable-table.hbs
+++ b/app/components/sortable-table.hbs
@@ -1,125 +1,46 @@
 <table class="sortable-table min-w-full divide-y divide-gray-200">
   <thead class="bg-gray-50">
     <tr>
-      <th
-        scope="col"
-        class="sortable text-left"
+      <SortableTableHeader
+        @field="title"
+        @sortOrder={{this.sortOrder}}
+        @sortBy={{this.sortBy}}
+        @setSortBy={{this.setSortBy}}
       >
-        <button class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase" type="button" {{on "click" (fn this.sortBy "title")}}>
-          <span class="col-heading m-2">Failure</span>
-          <div class="sort-arrow inline-block w-4" aria-hidden="true">
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-asc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,9.988c-0.543,-0.007 -0.988,-0.456 -0.988,-1c0,-0.259 0.101,-0.509 0.281,-0.695l4,-4c0.388,-0.388 1.026,-0.388 1.414,-0l4,4c0.388,0.388 0.388,1.026 -0,1.414c-0.23,0.23 -0.548,0.324 -0.85,0.281l-7.857,-0l0,-0Z"/>
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-asc" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-desc" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-desc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,4.012c-0.543,0.007 -0.988,0.456 -0.988,1c0,0.259 0.101,0.509 0.281,0.695l4,4c0.388,0.388 1.026,0.388 1.414,-0l4,-4c0.388,-0.388 0.388,-1.026 -0,-1.414c-0.23,-0.23 -0.548,-0.324 -0.85,-0.281l-7.857,0l0,0Z"/>
-            </svg>
-          </div>
-        </button>
-      </th>
-      <th
-        scope="col"
-        class="sortable text-left"
+        Failure
+      </SortableTableHeader>
+      <SortableTableHeader
+        @field="linting"
+        @sortOrder={{this.sortOrder}}
+        @sortBy={{this.sortBy}}
+        @setSortBy={{this.setSortBy}}
       >
-        <button class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase" type="button" {{on "click" (fn this.sortBy "linting")}}>
-          <span class="col-heading m-2">Linting Status</span>
-          <div class="sort-arrow inline-block w-4" aria-hidden="true">
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-asc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,9.988c-0.543,-0.007 -0.988,-0.456 -0.988,-1c0,-0.259 0.101,-0.509 0.281,-0.695l4,-4c0.388,-0.388 1.026,-0.388 1.414,-0l4,4c0.388,0.388 0.388,1.026 -0,1.414c-0.23,0.23 -0.548,0.324 -0.85,0.281l-7.857,-0l0,-0Z"/>
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-asc" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-desc" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-desc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,4.012c-0.543,0.007 -0.988,0.456 -0.988,1c0,0.259 0.101,0.509 0.281,0.695l4,4c0.388,0.388 1.026,0.388 1.414,-0l4,-4c0.388,-0.388 0.388,-1.026 -0,-1.414c-0.23,-0.23 -0.548,-0.324 -0.85,-0.281l-7.857,0l0,0Z"/>
-            </svg>
-          </div>
-        </button>
-      </th>
-      <th
-        scope="col"
-        class="sortable text-left"
+        Linting Status
+      </SortableTableHeader>
+      <SortableTableHeader
+        @field="testing"
+        @sortOrder={{this.sortOrder}}
+        @sortBy={{this.sortBy}}
+        @setSortBy={{this.setSortBy}}
       >
-        <button class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase" type="button" {{on "click" (fn this.sortBy "testing")}}>
-          <span class="col-heading m-2">Testing Status</span>
-          <div class="sort-arrow inline-block w-4" aria-hidden="true">
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-asc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,9.988c-0.543,-0.007 -0.988,-0.456 -0.988,-1c0,-0.259 0.101,-0.509 0.281,-0.695l4,-4c0.388,-0.388 1.026,-0.388 1.414,-0l4,4c0.388,0.388 0.388,1.026 -0,1.414c-0.23,0.23 -0.548,0.324 -0.85,0.281l-7.857,-0l0,-0Z"/>
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-asc" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-desc" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-desc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,4.012c-0.543,0.007 -0.988,0.456 -0.988,1c0,0.259 0.101,0.509 0.281,0.695l4,4c0.388,0.388 1.026,0.388 1.414,-0l4,-4c0.388,-0.388 0.388,-1.026 -0,-1.414c-0.23,-0.23 -0.548,-0.324 -0.85,-0.281l-7.857,0l0,0Z"/>
-            </svg>
-          </div>
-        </button>
-      </th>
-      <th scope="col" class="sortable text-left">
-        <button
-          class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase"
-          type="button" {{on "click" (fn this.sortBy "manual" )}}>
-          <span class="col-heading m-2">Manual Testing Status</span>
-          <div class="sort-arrow inline-block w-4" aria-hidden="true">
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-asc hidden" width="100%" height="100%"
-              viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2"
-                d="M3,9.988c-0.543,-0.007 -0.988,-0.456 -0.988,-1c0,-0.259 0.101,-0.509 0.281,-0.695l4,-4c0.388,-0.388 1.026,-0.388 1.414,-0l4,4c0.388,0.388 0.388,1.026 -0,1.414c-0.23,0.23 -0.548,0.324 -0.85,0.281l-7.857,-0l0,-0Z" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-asc"
-              viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd"
-                d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z"
-                clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-desc"
-              viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd"
-                d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-desc hidden" width="100%"
-              height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2"
-                d="M3,4.012c-0.543,0.007 -0.988,0.456 -0.988,1c0,0.259 0.101,0.509 0.281,0.695l4,4c0.388,0.388 1.026,0.388 1.414,-0l4,-4c0.388,-0.388 0.388,-1.026 -0,-1.414c-0.23,-0.23 -0.548,-0.324 -0.85,-0.281l-7.857,0l0,0Z" />
-            </svg>
-          </div>
-        </button>
-      </th>
-      <th
-        scope="col"
-        class="sortable text-left"
+        Testing Status
+      </SortableTableHeader>
+      <SortableTableHeader
+        @field="manual"
+        @sortOrder={{this.sortOrder}}
+        @sortBy={{this.sortBy}}
+        @setSortBy={{this.setSortBy}}
       >
-        <button class="sort-toggle flex items-center w-full text-left px-6 py-3 text-xs tracking-wider font-medium text-gray-800 uppercase" type="button" {{on "click" (fn this.sortBy "webAimLevel")}}>
-          <span class="col-heading m-2">Level</span>
-          <div class="sort-arrow inline-block w-4" aria-hidden="true">
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-asc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,9.988c-0.543,-0.007 -0.988,-0.456 -0.988,-1c0,-0.259 0.101,-0.509 0.281,-0.695l4,-4c0.388,-0.388 1.026,-0.388 1.414,-0l4,4c0.388,0.388 0.388,1.026 -0,1.414c-0.23,0.23 -0.548,0.324 -0.85,0.281l-7.857,-0l0,-0Z"/>
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-asc" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="icon-sort-open icon-sort-desc" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-            </svg>
-            <svg focusable="false" aria-hidden="true" class="icon-sort-filled icon-sort-desc hidden" width="100%" height="100%" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-              <path fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" d="M3,4.012c-0.543,0.007 -0.988,0.456 -0.988,1c0,0.259 0.101,0.509 0.281,0.695l4,4c0.388,0.388 1.026,0.388 1.414,-0l4,-4c0.388,-0.388 0.388,-1.026 -0,-1.414c-0.23,-0.23 -0.548,-0.324 -0.85,-0.281l-7.857,0l0,0Z"/>
-            </svg>
-          </div>
-        </button>
-      </th>
+        Manual Testing Status
+      </SortableTableHeader>
+      <SortableTableHeader
+        @field="webAimLevel"
+        @sortOrder={{this.sortOrder}}
+        @sortBy={{this.sortBy}}
+        @setSortBy={{this.setSortBy}}
+      >
+        Level
+      </SortableTableHeader>
     </tr>
   </thead>
   <tbody class="bg-white divide-y divide-gray-200">

--- a/app/components/sortable-table.hbs
+++ b/app/components/sortable-table.hbs
@@ -3,40 +3,40 @@
     <tr>
       <SortableTableHeader
         @field="title"
-        @sortOrder={{this.sortOrder}}
-        @sortBy={{this.sortBy}}
+        @sortOrder={{@sortOrder}}
+        @sortBy={{@sortBy}}
         @setSortBy={{this.setSortBy}}
       >
         Failure
       </SortableTableHeader>
       <SortableTableHeader
         @field="linting"
-        @sortOrder={{this.sortOrder}}
-        @sortBy={{this.sortBy}}
+        @sortOrder={{@sortOrder}}
+        @sortBy={{@sortBy}}
         @setSortBy={{this.setSortBy}}
       >
         Linting Status
       </SortableTableHeader>
       <SortableTableHeader
         @field="testing"
-        @sortOrder={{this.sortOrder}}
-        @sortBy={{this.sortBy}}
+        @sortOrder={{@sortOrder}}
+        @sortBy={{@sortBy}}
         @setSortBy={{this.setSortBy}}
       >
         Testing Status
       </SortableTableHeader>
       <SortableTableHeader
         @field="manual"
-        @sortOrder={{this.sortOrder}}
-        @sortBy={{this.sortBy}}
+        @sortOrder={{@sortOrder}}
+        @sortBy={{@sortBy}}
         @setSortBy={{this.setSortBy}}
       >
         Manual Testing Status
       </SortableTableHeader>
       <SortableTableHeader
         @field="webAimLevel"
-        @sortOrder={{this.sortOrder}}
-        @sortBy={{this.sortBy}}
+        @sortOrder={{@sortOrder}}
+        @sortBy={{@sortBy}}
         @setSortBy={{this.setSortBy}}
       >
         Level

--- a/app/components/sortable-table.js
+++ b/app/components/sortable-table.js
@@ -3,34 +3,27 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class SortableTableComponent extends Component {
-  @tracked sort = '';
-  reverseSort = false;
+  @tracked sortBy = '';
+  @tracked sortOrder = 'asc';
+
+  get sort() {
+    return `${this.sortBy}:${this.sortOrder}`;
+  }
 
   @action
-  sortBy(type) {
-    const sortOrder = this.reverseSort ? 'desc' : 'asc';
-    this.reverseSort = !this.reverseSort;
-    this.sort = `${type}:${sortOrder}`;
+  setSortBy(type) {
+    if (this.sortBy === type) {
+      //invert the sort order
+      this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortBy = type;
+      this.sortOrder = 'asc';
+    }
 
-    const columnHeadings = document.querySelectorAll('.sortable');
     const currentColHeading = event.target.parentElement;
-    columnHeadings.forEach(colHeading => { colHeading.removeAttribute('aria-sort') });
-    currentColHeading.setAttribute('aria-sort', `${sortOrder}ending`);
-
-    // reset all arrows
-    const filledArrows = document.querySelectorAll('.icon-sort-filled');
-    const openArrows = document.querySelectorAll('.icon-sort-open');
-    filledArrows.forEach(arrow => arrow.classList.add('hidden'));
-    openArrows.forEach(arrow => arrow.classList.remove('hidden'));
-
-    // style target arrows
-    const targetFilledArrow = currentColHeading.querySelector(`.icon-sort-${sortOrder}.icon-sort-filled`);
-    const targetOpenArrow = currentColHeading.querySelector(`.icon-sort-${sortOrder}.icon-sort-open`);
-    targetFilledArrow.classList.remove('hidden');
-    targetOpenArrow.classList.add('hidden');
 
     const liveRegion = document.getElementById('a11y-notification');
-    liveRegion.innerHTML = `Sorted by ${currentColHeading.querySelector('.col-heading').innerText} ${sortOrder}ending`;
+    liveRegion.innerHTML = `Sorted by ${currentColHeading.querySelector('.col-heading').innerText} ${this.sortBy}ending`;
     setTimeout(function () {
       liveRegion.innerHTML = '';
     }, 1000);

--- a/app/components/sortable-table.js
+++ b/app/components/sortable-table.js
@@ -1,23 +1,19 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 
 export default class SortableTableComponent extends Component {
-  @tracked sortBy = '';
-  @tracked sortOrder = 'asc';
-
   get sort() {
-    return `${this.sortBy}:${this.sortOrder}`;
+    return `${this.args.sortBy}:${this.args.sortOrder}`;
   }
 
   @action
   setSortBy(type) {
-    if (this.sortBy === type) {
+    if (this.args.sortBy === type) {
       //invert the sort order
-      this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
+      this.args.setSortOrder(this.args.sortOrder === 'asc' ? 'desc' : 'asc');
     } else {
-      this.sortBy = type;
-      this.sortOrder = 'asc';
+      this.args.setSortBy(type);
+      this.args.setSortOrder('asc');
     }
 
     const currentColHeading = event.target.parentElement;

--- a/app/controllers/violations/index.js
+++ b/app/controllers/violations/index.js
@@ -1,0 +1,20 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ViolationsIndexController extends Controller {
+  @tracked sortBy = '';
+  @tracked sortOrder = 'asc';
+
+  queryParams = ['sortBy', 'sortOrder'];
+
+  @action
+  setSortBy(value) {
+    this.sortBy = value;
+  }
+
+  @action
+  setSortOrder(value) {
+    this.sortOrder = value;
+  }
+}

--- a/app/templates/violations/index.hbs
+++ b/app/templates/violations/index.hbs
@@ -17,7 +17,13 @@
             <div
               class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg"
             >
-              <SortableTable @model={{@model}} />
+              <SortableTable
+                @model={{@model}}
+                @sortBy={{this.sortBy}}
+                @sortOrder={{this.sortOrder}}
+                @setSortBy={{this.setSortBy}}
+                @setSortOrder={{this.setSortOrder}}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
The goal of this PR is just to add the sortOrder and sortBy values to query params so that we are able to share a link and maintain the sort order. 

To achieve this I did the following: 

- extract out the `<th>` implementation from `<SortableTable />` into a component
- move the implementation of styling sort arrows to use glimmer instead of manual DOM manipulation
- make the sortOrder and sortBy values component arguments so they can be set by the controller
- use DDAU to get and set the sortBy and sortOrder values

Let me know if you have any questions 👍 

p.s. this **will** conflict with https://github.com/MelSumner/a11y-automation/pull/269 so if you want to review and merge that first I'm happy to rebase and fix the conflicts 