### PR TITLE
Replace `npm install` with `yarn` instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To work on this app locally, follow these steps:
 
 1. clone this repository -- `git clone https://github.com/MelSumner/a11y-automation.git`
 2. switch to this app's directory -- `cd a11y-automation`
-3. run `npm install` to install missing dependencies
+3. run `yarn` to install missing dependencies
 4. run `ember s` to build the app. If it all works, it'll be available at `http://localhost:4200/` in your browser of choice.
 
 The styles in this app are primarily provided by Tailwind.


### PR DESCRIPTION
Our lock file is `yarn.lock`, so it makes sense to tell people to use yarn to install dependencies. Either that or we should shift to package-lock.json (npm equivalent).