### PR TITLE
Remove hover for homepage tiles

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -70,7 +70,7 @@
           </p>
           <div class="mt-12">
             <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-              <div class="pt-6 group hover:bg-gray-50 hover:shadow-lg dark:hover:bg-gray-800">
+              <div class="pt-6">
                 <div class="flow-root bg-gray-50 dark:bg-gray-800 rounded-lg px-6 pb-8">
                   <div class="-mt-6">
                     <div>
@@ -100,7 +100,7 @@
                   </div>
                 </div>
               </div>
-              <div class="pt-6 group hover:bg-gray-50 dark:hover:bg-gray-800 hover:shadow-lg">
+              <div class="pt-6">
                 <div class="flow-root bg-gray-50 dark:bg-gray-800 rounded-lg px-6 pb-8">
                   <div class="-mt-6">
                     <div>
@@ -130,7 +130,7 @@
                   </div>
                 </div>
               </div>
-              <div class="pt-6 group hover:bg-gray-50 dark:hover:bg-gray-800 hover:shadow-lg">
+              <div class="pt-6">
                 <div class="flow-root bg-gray-50 dark:bg-gray-800 rounded-lg px-6 pb-8">
                   <div class="-mt-6">
                     <div>
@@ -160,7 +160,7 @@
                   </div>
                 </div>
               </div>
-              <div class="pt-6 group hover:bg-gray-50 dark:hover:bg-gray-800 hover:shadow-lg">
+              <div class="pt-6">
                 <div class="flow-root bg-gray-50 dark:bg-gray-800 rounded-lg px-6 pb-8">
                   <div class="-mt-6">
                     <div>
@@ -190,7 +190,7 @@
                   </div>
                 </div>
               </div>
-              <div class="pt-6 group hover:bg-gray-50 dark:hover:bg-gray-800 hover:shadow-lg">
+              <div class="pt-6">
                 <div class="flow-root bg-gray-50 dark:bg-gray-800 rounded-lg px-6 pb-8">
                   <div class="-mt-6">
                     <div>
@@ -231,7 +231,7 @@
                   </div>
                 </div>
               </div>
-              <div class="pt-6 group hover:bg-gray-50 dark:hover:bg-gray-800 hover:shadow-lg">
+              <div class="pt-6">
                 <div class="flow-root bg-gray-50 dark:bg-gray-800 rounded-lg px-6 pb-8">
                   <div class="-mt-6">
                     <div>


### PR DESCRIPTION
As discussed with @MelSumner this removes the `hover` effect on the home page. The `div class=pt-6` is still needed to make the `purple` blocks stand out of the other one