### PR TITLE
fix referenced rule name

### DIFF
--- a/violations/missing-alt-attribute.md
+++ b/violations/missing-alt-attribute.md
@@ -14,7 +14,7 @@ The `alt` attribute should not be missing on `<img>` elements, `<area>` elements
 ## Automation
 
 ### Linting
-See the [`ember-template-lint`](https://github.com/ember-template-lint/ember-template-lint) library for the `require-valid-alt` rule.
+See the [`ember-template-lint`](https://github.com/ember-template-lint/ember-template-lint) library for the `require-valid-alt-text` rule.
 
 ### Testing
 See the [`axe-core`](https://github.com/dequelabs/axe-core) library for the `role-img-alt`, `input-image-alt`, `image-alt rules`.


### PR DESCRIPTION
This just fixes the rule name to what it is actually called in ember-template-lint https://github.com/ember-template-lint/ember-template-lint/blob/master/lib/rules/require-valid-alt-text.js