### PR TITLE
Update index.hbs

### DIFF
--- a/app/templates/violations/index.hbs
+++ b/app/templates/violations/index.hbs
@@ -7,7 +7,7 @@
   </header>
   <main id="main">
     <div class="max-w-6xl mx-auto py-6 sm:px-6 lg:px-8 flex flex-col align-middle inline-block">
-      <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+      <div class="shadow border-b border-gray-200 sm:rounded-lg">
         <p class="min-w-full w-full p-4 mt-4 mb-8 mx-auto border-2 rounded-lg border-indigo-700 dark:border-yellow-300 dark:text-gray-50">This is a work in progress! See the <a href="https://github.com/MelSumner/a11y-automation/issues/10">primary tracking issue</a> for a full list of potential violations and the progress of the todos in the issue. This message will be removed once all todos have been completed. PRs welcome!</p>
         <SortableTable
           @model={{@model}}


### PR DESCRIPTION
If merged, this PR removes the "overflow-hidden" class that was preventing natural scrolling for the violations table on small viewports.