### PR TITLE
Add in Luma (PEAT alternative)

### DIFF
--- a/app/routes/automated-tools.js
+++ b/app/routes/automated-tools.js
@@ -72,12 +72,16 @@ export default class AutomatedToolsRoute extends Route {
         category: 'Testing Engine',
         description: 'A accessibility testing engine for JavaScript.',
         link: 'https://github.com/dequelabs/axe-core'
-      },
-      {
+      }, {
         title: 'keyboard-testing-library',
-        category: 'Testing Tool',
-        description: 'An extension of Testing Library focused on simulating keyboard-only users behaviors ',
+        category: 'Testing Library',
+        description: 'An extension of Testing Library focused on simulating keyboard-only users behaviors.',
         link: 'https://www.npmjs.com/package/keyboard-testing-library'
+      }, {
+        title: 'Luma',
+        category: 'Testing Tool',
+        description: 'A powerful and accurate photosensitive epilepsy seizure triggers detection tool.',
+        link: 'https://www.includia.com/luma/upload'
       },
     ];
 


### PR DESCRIPTION
I remember I had this in my personal knowledge base and wanted to add it for consideration here because I'd never heard of an alternative to PEAT before for testing for epilepsy safety.

I'm not sure if there's a dedicated API version yet (I think using the web UI is the only option), but I figured it was worth bringing up in any case (since it's more automated than manually reviewing videos)

No worries if it doesn't make sense here though!