### PR TITLE
Remove old Internet Explorer Meta tag

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,7 +11,6 @@
       }
     </script>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>A11yAutomation</title>
     <meta name="description" content="A11Y Automation Tracker">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">


### PR DESCRIPTION
This is no longer needed.
REF: https://webhint.io/docs/user-guide/hints/hint-highest-available-document-mode/?source=devtools