### PR TITLE
Add ANDI to automated tools list

### DIFF
--- a/app/routes/automated-tools.js
+++ b/app/routes/automated-tools.js
@@ -6,7 +6,7 @@ export default class AutomatedToolsRoute extends Route {
       { title: 'ember-a11y-testing',
         category: 'Testing Library',
         description: 'Accessibility testing for Ember apps; provides middleware that allows the browser to talk to the node process running the tests via testem.',
-        link: 'https://github.com/ember-a11y/ember-a11y-testing' 
+        link: 'https://github.com/ember-a11y/ember-a11y-testing'
       },
       { title: 'ember-template-lint',
         category: 'Code Linter (Static)',
@@ -143,6 +143,12 @@ export default class AutomatedToolsRoute extends Route {
         description: 'A user-friendly automatic content accessibility checker.',
         link: 'https://editoria11y.princeton.edu/'
       },
+      {
+        title: 'ANDI (Accessible Name & Description Inspector)',
+        category: 'Browser Extension',
+        description: 'ANDI is a free open-source tool that can be used to test websites for conformance to the Web Content Accessibility Guidelines (WCAG) 2.0 Level A and AA success criteria.',
+        link: 'https://www.ssa.gov/accessibility/andi/help/install.html'
+      }
     ];
 
     tools.sort((a, b) => (a.category > b.category) ? 1 : -1)


### PR DESCRIPTION
If merged, this PR adds the US SSA's ANDI tool to the list of automated tools. 

It is free, convenient to use (bookmarkable js script), and often used by US Government Agencies for Section 508 audits.

Render:

<img width="2032" alt="Screenshot 2024-06-07 at 09 33 57" src="https://github.com/MelSumner/a11y-automation/assets/33584866/ad1581ef-3984-4728-bc11-3010ee1f6ab8">
